### PR TITLE
feat: update training manual to modonomicon 26.1.2

### DIFF
--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/inherit/inherit.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/inherit/inherit.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/inherit/inherit",
     "name": "book.umapyoi.trainers_manual.inherit.inherit.name",
     "icon": "umapyoi:three_goddess",
     "category": "umapyoi:inherit",
@@ -8,14 +10,20 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.inherit.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.inherit.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.inherit.page2.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/inherit/register_table.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/inherit/register_table.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/inherit/register_table",
     "name": "book.umapyoi.trainers_manual.inherit.register_table.name",
     "icon": "umapyoi:register_lectern",
     "category": "umapyoi:inherit",
@@ -8,18 +10,25 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.register_table.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.register_table.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.register_table.page2.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page3",
             "recipe_id_1": "umapyoi:register_lectern",
             "text": "book.umapyoi.trainers_manual.inherit.register_table.page3.text"
         }

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/inherit/wish.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/inherit/wish.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/inherit/wish",
     "name": "book.umapyoi.trainers_manual.inherit.wish.name",
     "icon": "umapyoi:uma_factor_item",
     "category": "umapyoi:inherit",
@@ -8,18 +10,26 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.wish.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.wish.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.wish.page2.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page3",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.inherit.wish.page3.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/others/clothing.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/others/clothing.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/others/clothing",
     "name": "book.umapyoi.trainers_manual.others.clothing.name",
     "icon": "umapyoi:summer_uniform",
     "category": "umapyoi:others",
@@ -8,20 +10,25 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.others.clothing.page0.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page1",
             "recipe_id_1": "umapyoi:summer_uniform",
             "text": "book.umapyoi.trainers_manual.others.clothing.page1.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page2",
             "recipe_id_1": "umapyoi:winter_uniform",
             "text": "book.umapyoi.trainers_manual.others.clothing.page2.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page3",
             "recipe_id_1": "umapyoi:trainning_suit",
             "text": "book.umapyoi.trainers_manual.others.clothing.page3.text"
         }

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/others/disassemble.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/others/disassemble.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/others/disassemble",
     "name": "book.umapyoi.trainers_manual.others.disassemble.name",
     "icon": "umapyoi:disassembly_block",
     "category": "umapyoi:others",
@@ -8,10 +10,13 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.others.disassemble.page0.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page1",
             "recipe_id_1": "umapyoi:disassembly_block",
             "text": "book.umapyoi.trainers_manual.others.disassemble.page1.text"
         }

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/others/foods.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/others/foods.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/others/foods",
     "name": "book.umapyoi.trainers_manual.others.foods.name",
     "icon": "umapyoi:royal_bitter",
     "category": "umapyoi:others",
@@ -8,18 +10,25 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.others.foods.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.others.foods.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.others.foods.page2.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page3",
             "recipe_id_1": "umapyoi:hachimi_mid",
             "recipe_id_2": "umapyoi:hachimi_big",
             "title1": "book.umapyoi.trainers_manual.others.foods.page3.title1",
@@ -27,6 +36,7 @@
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page4",
             "recipe_id_1": "umapyoi:cupcake",
             "recipe_id_2": "umapyoi:sweet_cupcake",
             "title1": "book.umapyoi.trainers_manual.others.foods.page4.title1",
@@ -34,6 +44,7 @@
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page5",
             "recipe_id_1": "umapyoi:small_energy_drink",
             "recipe_id_2": "umapyoi:medium_energy_drink",
             "title1": "book.umapyoi.trainers_manual.others.foods.page5.title1",
@@ -41,6 +52,7 @@
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page6",
             "recipe_id_1": "umapyoi:large_energy_drink",
             "recipe_id_2": "umapyoi:royal_bitter",
             "title1": "book.umapyoi.trainers_manual.others.foods.page6.title1",

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/prologue/credits.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/prologue/credits.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/prologue/credits",
     "name": "book.umapyoi.trainers_manual.prologue.credits.name",
     "icon": "minecraft:writable_book",
     "category": "umapyoi:prologue",
@@ -8,10 +10,14 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.prologue.credits.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.prologue.credits.page1.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/prologue/prologue.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/prologue/prologue.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/prologue/prologue",
     "name": "book.umapyoi.trainers_manual.prologue.prologue.name",
     "icon": "umapyoi:blank_uma_soul",
     "category": "umapyoi:prologue",
@@ -8,14 +10,20 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.prologue.prologue.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.prologue.prologue.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.prologue.prologue.page2.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/status.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/status.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/training/status",
     "name": "book.umapyoi.trainers_manual.training.status.name",
     "icon": "umapyoi:skill_book",
     "category": "umapyoi:training",
@@ -8,34 +10,50 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page2.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page3",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page3.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page4",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page4.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page5",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page5.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page6",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page6.text"
         },
         {
             "type": "modonomicon:image",
+            "id": "page7",
+            "title": "",
             "use_legacy_rendering": true,
             "images": [
                 "umapyoi:textures/book_images/skills.png"
@@ -44,18 +62,25 @@
         },
         {
             "type": "modonomicon:text",
+            "id": "page8",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page8.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page9",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page9.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page10",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.status.page10.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page11",
             "recipe_id_1": "umapyoi:skill_learning_table",
             "text": "book.umapyoi.trainers_manual.training.status.page11.text"
         }

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/support_card.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/support_card.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/training/support_card",
     "name": "book.umapyoi.trainers_manual.training.support_card.name",
     "icon": "umapyoi:support_card",
     "category": "umapyoi:training",
@@ -8,38 +10,56 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page2.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page3",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page3.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page4",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page4.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page5",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page5.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page6",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page6.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page7",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page7.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page8",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.support_card.page8.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/training_books.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/training_books.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/training/training_books",
     "name": "book.umapyoi.trainers_manual.training.training_books.name",
     "icon": "umapyoi:speed_high_item",
     "category": "umapyoi:training",
@@ -8,10 +10,14 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.training_books.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.training_books.page1.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/training_terminal.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/training/training_terminal.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/training/training_terminal",
     "name": "book.umapyoi.trainers_manual.training.training_terminal.name",
     "icon": "umapyoi:training_facility",
     "category": "umapyoi:training",
@@ -8,22 +10,31 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.training_terminal.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.training_terminal.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.training_terminal.page2.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page3",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.training.training_terminal.page3.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page4",
             "recipe_id_1": "umapyoi:training_facility",
             "text": "book.umapyoi.trainers_manual.training.training_terminal.page4.text"
         }

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/jewel.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/jewel.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/uma_soul/jewel",
     "name": "book.umapyoi.trainers_manual.uma_soul.jewel.name",
     "icon": "umapyoi:jewel",
     "category": "umapyoi:uma_soul",
@@ -8,10 +10,13 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.jewel.page0.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page1",
             "recipe_id_1": "umapyoi:jewel",
             "text": "book.umapyoi.trainers_manual.uma_soul.jewel.page1.text",
             "title1": "book.umapyoi.trainers_manual.uma_soul.jewel.page1.title1",

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/motivations.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/motivations.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/uma_soul/motivations",
     "name": "book.umapyoi.trainers_manual.uma_soul.motivations.name",
     "icon": "umapyoi:textures/book_images/motivations_icon.png",
     "category": "umapyoi:uma_soul",
@@ -8,14 +10,20 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.motivations.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.motivations.page1.text"
         },
         {
             "type": "modonomicon:image",
+            "id": "page2",
+            "title": "",
             "use_legacy_rendering": true,
             "images": [
                 "umapyoi:textures/book_images/motivations.png"
@@ -24,6 +32,8 @@
         },
         {
             "type": "modonomicon:text",
+            "id": "page3",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.motivations.page3.text"
         }
     ]

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/pedestal.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/pedestal.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/uma_soul/pedestal",
     "name": "book.umapyoi.trainers_manual.uma_soul.pedestal.name",
     "icon": "umapyoi:uma_pedestal",
     "category": "umapyoi:uma_soul",
@@ -8,18 +10,25 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.pedestal.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.pedestal.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.pedestal.page2.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page3",
             "recipe_id_1": "umapyoi:silver_uma_pedestal",
             "recipe_id_2": "umapyoi:uma_pedestal",
             "title1": "book.umapyoi.trainers_manual.uma_soul.pedestal.page3.title1",

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/three_goddesses.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/three_goddesses.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/uma_soul/three_goddesses",
     "name": "book.umapyoi.trainers_manual.uma_soul.three_goddesses.name",
     "icon": "umapyoi:three_goddess",
     "category": "umapyoi:uma_soul",
@@ -8,10 +10,13 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.three_goddesses.page0.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page1",
             "recipe_id_1": "umapyoi:three_goddess",
             "text": "book.umapyoi.trainers_manual.uma_soul.three_goddesses.page1.text"
         }

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/tickets.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/tickets.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/uma_soul/tickets",
     "name": "book.umapyoi.trainers_manual.uma_soul.tickets.name",
     "icon": "umapyoi:blank_ticket",
     "category": "umapyoi:uma_soul",
@@ -8,19 +10,25 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.tickets.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.tickets.page1.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page2",
             "recipe_id_1": "umapyoi:blank_ticket",
             "text": "book.umapyoi.trainers_manual.uma_soul.tickets.page2.text"
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page3",
             "recipe_id_1": "umapyoi:uma_ticket",
             "recipe_id_2": "umapyoi:card_ticket",
             "title1": "book.umapyoi.trainers_manual.uma_soul.tickets.page3.title1",
@@ -28,6 +36,7 @@
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page4",
             "recipe_id_1": "umapyoi:sr_uma_ticket",
             "recipe_id_2": "umapyoi:sr_card_ticket",
             "title1": "book.umapyoi.trainers_manual.uma_soul.tickets.page4.title1",
@@ -35,6 +44,7 @@
         },
         {
             "type": "modonomicon:crafting_recipe",
+            "id": "page5",
             "recipe_id_1": "umapyoi:ssr_uma_ticket",
             "recipe_id_2": "umapyoi:ssr_card_ticket",
             "title1": "book.umapyoi.trainers_manual.uma_soul.tickets.page5.title1",

--- a/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/uma_soul.json
+++ b/src/main/resources/data/umapyoi/modonomicon/books/trainers_manual/entries/uma_soul/uma_soul.json
@@ -1,4 +1,6 @@
 {
+    "type": "modonomicon:content",
+    "id": "trainers_manual/uma_soul/uma_soul",
     "name": "book.umapyoi.trainers_manual.uma_soul.uma_soul.name",
     "icon": "umapyoi:uma_soul",
     "category": "umapyoi:uma_soul",
@@ -8,18 +10,26 @@
     "pages": [
         {
             "type": "modonomicon:text",
+            "id": "page0",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.uma_soul.page0.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page1",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.uma_soul.page1.text"
         },
         {
             "type": "modonomicon:text",
+            "id": "page2",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.uma_soul.page2.text"
         },
         {
             "type": "modonomicon:image",
+            "id": "page3",
+            "title": "",
             "use_legacy_rendering": true,
             "images": [
                 "umapyoi:textures/book_images/summon_soul.png",
@@ -29,10 +39,14 @@
         },
         {
             "type": "modonomicon:text",
+            "id": "page4",
+            "title": "",
             "text": "book.umapyoi.trainers_manual.uma_soul.uma_soul.page4.text"
         },
         {
             "type": "modonomicon:image",
+            "id": "page5",
+            "title": "",
             "use_legacy_rendering": true,
             "images": [
                 "umapyoi:textures/book_images/hud_info.png"


### PR DESCRIPTION
Updates the training manual jsons to load properly in latest modonomicon.
Already targets the upcoming 2.0.0 of modonomicon, but should probably also load in 1.x on 26.1.2 :) 